### PR TITLE
Log http status code in the 300-400 range with debug

### DIFF
--- a/grpcutil/middlewares/gerr/gerr_middleware.go
+++ b/grpcutil/middlewares/gerr/gerr_middleware.go
@@ -71,12 +71,21 @@ func (m *ErrorMiddleware) handleError(ctx context.Context, handlerErr error) err
 	}
 	asertoErr = asertoErr.Int(errors.HTTPStatusErrorMetadata, asertoErr.HTTPCode)
 
-	log.Warn().Stack().Err(handlerErr).
-		Str("error-id", errID.String()).
-		Str("error-code", asertoErr.Code).
-		Int("status-code", int(asertoErr.StatusCode)).
-		Fields(asertoErr.Fields()).
-		Msg(asertoErr.Message)
+	if asertoErr.HTTPCode >= 300 && asertoErr.HTTPCode < 400 {
+		log.Debug().
+			Str("error-id", errID.String()).
+			Str("error-code", asertoErr.Code).
+			Int("status-code", int(asertoErr.StatusCode)).
+			Fields(asertoErr.Fields()).
+			Msg(asertoErr.Message)
+	} else {
+		log.Warn().Stack().Err(handlerErr).
+			Str("error-id", errID.String()).
+			Str("error-code", asertoErr.Code).
+			Int("status-code", int(asertoErr.StatusCode)).
+			Fields(asertoErr.Fields()).
+			Msg(asertoErr.Message)
+	}
 
 	errResult := status.New(asertoErr.StatusCode, asertoErr.Error())
 	errResult, err = errResult.WithDetails(&errdetails.ErrorInfo{


### PR DESCRIPTION
When we want to return HTTP status codes in the 300-400 range, the logs display them as WARN with an error message, although those are not errors. e.g.
<img width="2315" alt="Screenshot 2024-01-15 at 15 28 07" src="https://github.com/aserto-dev/aserto-grpc/assets/3924120/e7e169d4-3209-4cce-b2ae-944d3b48d189">

The PR logs the status codes between 300 and 400 with debug level and omits the error as those should not be errors. e.g.
<img width="1973" alt="Screenshot 2024-01-15 at 15 31 17" src="https://github.com/aserto-dev/aserto-grpc/assets/3924120/b6d0e5b6-55af-4de5-8b93-7d850e9e3d4b">

